### PR TITLE
Validate port pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PATH_CLASSES  = ./srcs/classes/
 PATH_OBJS	  =	./objs/
 
 INCLUDES = -I./includes
-FILES_SRC = main.cpp
+FILES_SRC = main.cpp utils.cpp
 FILES_COMMANDS = USER.cpp NICK.cpp PASS.cpp CAP.cpp QUIT.cpp JOIN.cpp \
 				LISTC.cpp PRIVMSG.cpp KICK.cpp PART.cpp WHO.cpp MODE.cpp TOPIC.cpp INVITE.cpp auxiliaries.cpp
 
@@ -83,7 +83,7 @@ $(PATH_OBJS)%.o: $(PATH_COMMANDS)%.cpp | $(PATH_OBJS)
 	@$(CC) $(FLAGS) $(INCLUDES) -c $< -o $@
 
 # Create the objs directory if it doesn't exist
-$(PATH_OBJS): 
+$(PATH_OBJS):
 	@mkdir -p $(PATH_OBJS)
 
 # Removes object files

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -23,7 +23,7 @@ class Server {
 		Server();
 		~Server();
 
-		void	serverInit(); //iniciar o server, temos que mandar a porta e o password p /ele 
+		void	serverInit(int port, std::string password); //iniciar o server, temos que mandar a porta e o password p /ele
 		void	serverSocket(); // criar o socket, fazer o bind, listen
 		void	acceptNewUser(); // aceitar um novo cliente
 		void	receiveNewData(int fd); // receber novos dados dos clientes
@@ -34,12 +34,12 @@ class Server {
 		void	closeFds(); // fechar todos os file descriptors
 		void	clearUsers(int fd); // limpar todos os clientes que estão no vector do server
 		void	clearChannels();
-		
+
 		// Getters
-		std::map<std::string, Channel*>& getChannels(); 
-		std::vector<User*>& getUsers(); 
-		const std::map<std::string, Channel*>& getChannels() const; 
-		const std::vector<User*>& getUsers() const; 
+		std::map<std::string, Channel*>& getChannels();
+		std::vector<User*>& getUsers();
+		const std::map<std::string, Channel*>& getChannels() const;
+		const std::vector<User*>& getUsers() const;
 
 		int getServerFd() const;
 };

--- a/includes/utils.hpp
+++ b/includes/utils.hpp
@@ -1,0 +1,10 @@
+#ifndef UTILS_HPP
+# define UTILS_HPP
+
+# include <string>
+
+namespace Utils {
+	int  validateInputs(const std::string& portStr, const std::string& password);
+}
+
+#endif // UTILS_HPP

--- a/srcs/classes/Server.cpp
+++ b/srcs/classes/Server.cpp
@@ -1,4 +1,4 @@
-#include "../../includes/Server.hpp" 
+#include "../../includes/Server.hpp"
 
 bool Server::_signal = false; // inicializar a variavel booleana
 
@@ -92,8 +92,9 @@ void Server::serverSocket() {
 	_fds.push_back(newPoll);
 }
 
-void Server::serverInit() {
-	this->_port = 4444;
+void Server::serverInit(int port, std::string password) {
+	this->_port = port;
+  this->_password = password;
 	serverSocket();
 
 	std::cout << "Server started on port " << this->_port << std::endl;
@@ -101,7 +102,7 @@ void Server::serverInit() {
 	std::cout << "Waiting for clients..." << std::endl;
 
 	while (Server::_signal == false) {
-		
+
 		if (poll(_fds.data(), _fds.size(), 0) == -1 && Server::_signal == false) {
 			throw std::runtime_error("Error: fail to poll.");
 		}

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,9 +1,21 @@
 #include "../includes/irc.hpp"
+#include "../includes/utils.hpp"
 
 int main(int argc, char **argv) {
 
 	if (argc != 3) {
 		std::cerr << "Usage: " << argv[0] << " <port> <password>." << std::endl;
+		return 1;
+	}
+  int port;
+  std::string portStr = argv[1];
+	std::string password = argv[2];
+
+	try {
+		port = Utils::validateInputs(portStr, password);
+	}
+	catch (const std::exception& e) {
+		std::cerr << "Error: " << e.what() << std::endl;
 		return 1;
 	}
 	Server ser;
@@ -14,7 +26,7 @@ int main(int argc, char **argv) {
 		CommandsArgs::populateMap(); //-> populate the map with the commands
 		signal(SIGINT, Server::signalHandler); // ctrl + c
 		signal(SIGQUIT, Server::signalHandler); // (ctrl + \)
-		ser.serverInit(); //-> initialize the server
+		ser.serverInit(port, password); //-> initialize the server
 	}
 	catch(const std::exception& e){
 		ser.closeFds(); //-> close the file descriptors

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -24,8 +24,8 @@ namespace Utils {
       ss >> port;
       if (ss.fail() || !ss.eof())
         errorMsg += "Invalid port number format. ";
-      else if (port < 1024 || port > 65535)
-        errorMsg += "Port must be between 1024 and 65535. ";
+      else if (port < 1024 || port > 49151)
+        errorMsg += "Port must be between 1024 and 49151. ";
     }
 
     // Validate password received

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -1,0 +1,41 @@
+#include <sstream> // needed for std::stringstream
+#include <stdexcept>
+#include <cstdlib>
+#include <cctype>
+#include "../includes/utils.hpp"
+
+namespace Utils {
+  int validateInputs(const std::string& portStr, const std::string& password) {
+    std::string errorMsg;
+
+    // Validate port received
+    bool validPort = true;
+    for (size_t i = 0; i < portStr.length(); ++i) {
+      if (!std::isdigit(portStr[i])) {
+        errorMsg += "Port must be a number. ";
+        validPort = false;
+        break;
+      }
+    }
+
+    int port = -1;
+    if (validPort) {
+      std::stringstream ss(portStr);
+      ss >> port;
+      if (ss.fail() || !ss.eof())
+        errorMsg += "Invalid port number format. ";
+      else if (port < 1024 || port > 65535)
+        errorMsg += "Port must be between 1024 and 65535. ";
+    }
+
+    // Validate password received
+    if (password.empty())
+      errorMsg += "Password cannot be empty.";
+
+    // Put errors together
+    if (!errorMsg.empty())
+      throw std::invalid_argument(errorMsg);
+
+    return port;
+  }
+}


### PR DESCRIPTION
Adiciona validação para porta e senha.

✅ Validação da senha: 
A senha não pode estar vazia.

✅ Validação da porta:
A porta deve conter apenas números.
A porta deve estar entre 1024 e 49151.
      - 0 a 1023: portas reservadas para o sistema, devem ser evitadas a menos que seja superuser.
      - 1024 a 49151: portas registradas, apropriadas para servidores.
      - 49152 a 65535: portas dinâmicas, usadas por clientes e não recomendadas para servidores.

✅ Em caso de múltiplos erros, todos são exibidos juntos para facilitar a correção.